### PR TITLE
Update mongodb.py

### DIFF
--- a/limits/aio/storage/mongodb.py
+++ b/limits/aio/storage/mongodb.py
@@ -30,8 +30,8 @@ class MongoDBStorage(Storage, MovingWindowSupport):
     """
 
     DEFAULT_OPTIONS: Dict[str, Union[float, str, bool]] = {
-        "serverSelectionTimeoutMS": 1000,
-        "connectTimeoutMS": 1000,
+        "serverSelectionTimeoutMS": 10000,
+        "connectTimeoutMS": 10000,
     }
     "Default options passed to :class:`~motor.motor_asyncio.AsyncIOMotorClient`"
 


### PR DESCRIPTION
Increasing the default timeout to 10 Seconds To acccomodate for slow connections -- Considering replica sets and shardiing.